### PR TITLE
Alternate nodes

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,7 +21,8 @@ console.log('-------------');
 log(`Loaded configuration:
 Username: ${config.name}
 Bias: ${config.peg ? config.peg_multi : 'Disabled'}
-RPC Node: ${config.node}`);
+RPC Node: ${config.node}
+Alternate Nodes: ${config.alternate_nodes.join(", ")}`);
 console.log('-------------');
 
 global.verbose = false;
@@ -80,6 +81,7 @@ class HiveAcc {
                     var msg = ('message' in err) ? err.message : err;
                     console.error('The error returned was:', msg);
                     if(tries < retry_conf.login_attempts) {
+                        switchNode()
                         console.error(`Will retry in ${retry_conf.login_delay} seconds`);
                         return delay(retry_conf.login_delay * 1000)
                           .then(() => resolve(this.loadAccount(reload, tries+1)))
@@ -150,6 +152,7 @@ class HiveAcc {
                         var msg = ('message' in err) ? err.message : err;
                         console.error(`reason: ${msg}`);
                         if(tries < retry_conf.feed_attempts) {
+                            switchNode()
                             console.error(`Will retry in ${retry_conf.feed_delay} seconds`);
                             return delay(retry_conf.feed_delay * 1000)
                               .then(() => this.publish_feed(rate, tries+1))
@@ -201,6 +204,13 @@ function main() {
             console.log('Dry Run. Not actually publishing.');
         }
     });
+}
+
+function switchNode(){
+    let currentNode = config.alternate_nodes.shift()
+    hive.api.setOptions({ url: currentNode })
+    config.alternate_nodes.push(currentNode)
+    console.log(`Switched node to ${currentNode}.`)
 }
 
 log('Attempting to login into account', config.name);

--- a/config.advanced.json
+++ b/config.advanced.json
@@ -5,6 +5,7 @@
     "peg": false,
     "peg_multi": 1.0,
     "node": "https://hivded.privex.io",
+    "alternate_nodes" : ["https://api.deathwing.me", "https://api.hive.blog"],
     "ex_symbol": "hive",
     "ex_compare": "usd",
     "base_symbol": "HBD",

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -18,6 +18,7 @@ var settings = {
 var defaults = {
     hive: {
         node: 'https://hived.privex.io/',
+        alternate_nodes : ["https://api.deathwing.me", "https://api.hive.blog"],
         ex_symbol: 'hive', ex_compare: 'usd',
         base_symbol: 'HBD', quote_symbol: 'HIVE',
     }
@@ -29,6 +30,7 @@ if(!('network' in config)) { config.network = 'hive'; }
 var ndef = defaults[config.network];
 
 if(!('node' in config)) { config.node = ndef.node; }
+if(!('alternate_nodes' in config)) { config.alternate_nodes = ndef.alternate_nodes; }
 // disable peg by default. 0% peg (bias)
 if(!('peg' in config)) { config.peg = false; }
 if(!('peg_multi' in config)) { config.peg_multi = 1; }
@@ -55,6 +57,10 @@ for(var t_arg of process.argv) {
     if (t_arg == 'publishnow') settings.shouldPublish = true;
     if (t_arg == 'dry') settings.dryRun = true;
     if (t_arg == 'publishonce') settings.publishOnce = true;
+}
+
+if (!config.alternate_nodes.includes(config.node)){
+    config.alternate_nodes.push(config.node)
 }
 
 settings.config = config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hivefeed-js",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hivefeed-js",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "Hive Price Feed in JS with automatic retry for down nodes",
   "repository": "https://github.com/someguy123/hivefeed-js",
   "main": "app.js",


### PR DESCRIPTION
Allows user to specify more nodes, and if theres a problem with the one that they provided, it will switch to one of the alternate provided nodes. 

Nodes are specified in config under `alternate_nodes, with usage being as follows:
`"alternate_nodes" : ["https://api.deathwing.me", "https://api.hive.blog"],`

The default provided alternate nodes are deathwing's(https://api.deathwing.me) and hive.blog's(https://api.hive.blog). If user doesn't specify the alternate_nodes, it will use those as alternate. Node will switch on error with get_account or error on posting.