### PR TITLE
Update hivejs and fix a reject undefined crash

### DIFF
--- a/app.js
+++ b/app.js
@@ -86,7 +86,7 @@ class HiveAcc {
                         console.error(`Will retry in ${retry_conf.login_delay} seconds`);
                         return delay(retry_conf.login_delay * 1000)
                             .then(() => resolve(this.loadAccount(reload, tries + 1)))
-                            .catch((e) => reject(e));
+                            .catch((e) => console.error(e));
                     }
                     console.error(`Giving up. Tried ${tries} times`);
                     return reject(`Failed to log in after ${tries} attempts.`);
@@ -109,7 +109,7 @@ class HiveAcc {
                             console.error(`Will retry in ${retry_conf.login_delay} seconds`);
                             return delay(retry_conf.login_delay * 1000)
                                 .then(() => resolve(this.loadAccount(reload, tries + 1)))
-                                .catch((e) => reject(e));
+                                .catch((e) => console.error(e));
                         }
                         console.error(`Giving up. Tried ${tries} times`);
                         return reject(`Failed to log in after ${tries} attempts.`);
@@ -122,7 +122,7 @@ class HiveAcc {
                             console.error(`Will retry in ${retry_conf.login_delay} seconds`);
                             return delay(retry_conf.login_delay * 1000)
                                 .then(() => resolve(this.loadAccount(reload, tries + 1)))
-                                .catch((e) => reject(e));
+                                .catch((e) => console.error(e));
                         }
                         console.error(`Giving up. Tried ${tries} times`);
                         return reject(`Failed to log in after ${tries} attempts.`);
@@ -218,7 +218,7 @@ class HiveAcc {
                                 console.error(`Will retry in ${retry_conf.feed_delay} seconds`);
                                 return delay(retry_conf.feed_attempts * 1000)
                                     .then(() => resolve(this.publish_feed(feed, tries + 1)))
-                                    .catch((e) => reject(e));
+                                    .catch((e) => console.error(e));
                             }
                             console.error(`Giving up. Tried ${tries} times`);
                             return reject(`Failed to publish in after ${tries} attempts.`);

--- a/app.js
+++ b/app.js
@@ -204,7 +204,7 @@ class HiveAcc {
                                 console.error(`Will retry in ${retry_conf.feed_delay} seconds`);
                                 return delay(retry_conf.feed_attempts * 1000)
                                     .then(() => resolve(this.publish_feed(feed, tries + 1)))
-                                    .catch((e) => reject(e));
+                                    .catch((e) => console.error(e));
                             }
                             console.error(`Giving up. Tried ${tries} times`);
                             return reject(`Failed to publish in after ${tries} attempts.`);

--- a/app.js
+++ b/app.js
@@ -249,7 +249,7 @@ class HiveAcc {
 
                                 log(`Data published at: ${new Date()}`); //Not cure if this one will work
                                 log('Successfully published feed.');
-                                log(`TXID: ${result.id} TXNUM: ${result.trx_num}`);
+                                log(`TXID: ${result.id}`);
                             });
                         } else {
                             this.signing_valid = false;
@@ -278,7 +278,7 @@ class HiveAcc {
                         }
                         log(`Data published at: ${new Date()}`); //Not cure if this one will work
                         log('Successfully published feed.');
-                        log(`TXID: ${r.id} TXNUM: ${r.trx_num}`);
+                        log(`TXID: ${r.id}`);
                     });
             } else {
                 console.error('Failed to publish feed... neither signing key or wif are valid');

--- a/app.js
+++ b/app.js
@@ -255,7 +255,7 @@ class HiveAcc {
                             this.signing_valid = false;
                             return delay(retry_conf.feed_attempts * 1000)
                                 .then(() => resolve(this.publish_feed(feed, tries + 1)))
-                                .catch((e) => reject(e));
+                                .catch((e) => console.error(e));
                         }
                     }
                 );

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "Chris <info@someguy123.com> (Someguy123)",
   "license": "GPL-3.0",
   "dependencies": {
-    "@hiveio/hive-js": "^0.8.12",
+    "@hiveio/hive-js": "^2.0.2",
     "request": "^2.74.0"
   }
 }


### PR DESCRIPTION
Been getting a complete crash of the script due to 'reject' being undefined.

I've swapped out the offending rejects for a console.error so that the script can actually continue and try to post a feed TX rather than completely crash.

I've also updated hivejs to version 2.0.2 and omitted the TXNUM from output as TXID is the only thing returned by hivejs now.

Fixes #21 and #19