### PR TITLE
Fix edge cases where retries would not execute.

### DIFF
--- a/app.js
+++ b/app.js
@@ -84,6 +84,7 @@ class HiveAcc {
                     if (tries < retry_conf.login_attempts) {
                         switchNode();
                         console.error(`Will retry in ${retry_conf.login_delay} seconds`);
+                        console.error('-------------');
                         return delay(retry_conf.login_delay * 1000)
                             .then(() => resolve(this.loadAccount(reload, tries + 1)))
                             .catch((e) => console.error(e));
@@ -107,6 +108,7 @@ class HiveAcc {
                         if (tries < retry_conf.login_attempts) {
                             switchNode();
                             console.error(`Will retry in ${retry_conf.login_delay} seconds`);
+                            console.error('-------------');
                             return delay(retry_conf.login_delay * 1000)
                                 .then(() => resolve(this.loadAccount(reload, tries + 1)))
                                 .catch((e) => console.error(e));
@@ -120,6 +122,7 @@ class HiveAcc {
                         if (tries < retry_conf.login_attempts) {
                             switchNode();
                             console.error(`Will retry in ${retry_conf.login_delay} seconds`);
+                            console.error('-------------');
                             return delay(retry_conf.login_delay * 1000)
                                 .then(() => resolve(this.loadAccount(reload, tries + 1)))
                                 .catch((e) => console.error(e));
@@ -202,8 +205,9 @@ class HiveAcc {
                             if (tries < retry_conf.feed_attempts) {
                                 switchNode();
                                 console.error(`Will retry in ${retry_conf.feed_delay} seconds`);
+                                console.error('-------------');
                                 return delay(retry_conf.feed_attempts * 1000)
-                                    .then(() => resolve(this.publish_feed(feed, tries + 1)))
+                                    .then(() => this.publish_feed(feed, tries + 1))
                                     .catch((e) => console.error(e));
                             }
                             console.error(`Giving up. Tried ${tries} times`);
@@ -216,8 +220,9 @@ class HiveAcc {
                                 await this.login();
                                 switchNode();
                                 console.error(`Will retry in ${retry_conf.feed_delay} seconds`);
+                                console.error('-------------');
                                 return delay(retry_conf.feed_attempts * 1000)
-                                    .then(() => resolve(this.publish_feed(feed, tries + 1)))
+                                    .then(() => this.publish_feed(feed, tries + 1))
                                     .catch((e) => console.error(e));
                             }
                             console.error(`Giving up. Tried ${tries} times`);
@@ -239,6 +244,7 @@ class HiveAcc {
                                         await this.login();
                                         switchNode();
                                         console.error(`Will retry in ${retry_conf.feed_delay} seconds`);
+                                        console.error('-------------');
                                         return delay(retry_conf.feed_delay * 1000)
                                             .then(() => this.publish_feed(rate, tries + 1))
                                             .catch(console.error);
@@ -250,11 +256,12 @@ class HiveAcc {
                                 log(`Data published at: ${new Date()}`); //Not cure if this one will work
                                 log('Successfully published feed.');
                                 log(`TXID: ${result.id}`);
+                                log('-------------');
                             });
                         } else {
                             this.signing_valid = false;
                             return delay(retry_conf.feed_attempts * 1000)
-                                .then(() => resolve(this.publish_feed(feed, tries + 1)))
+                                .then(() => this.publish_feed(feed, tries + 1))
                                 .catch((e) => console.error(e));
                         }
                     }
@@ -269,6 +276,7 @@ class HiveAcc {
                             if (tries < retry_conf.feed_attempts) {
                                 switchNode();
                                 console.error(`Will retry in ${retry_conf.feed_delay} seconds`);
+                                console.error('-------------');
                                 return delay(retry_conf.feed_delay * 1000)
                                     .then(() => this.publish_feed(rate, tries + 1))
                                     .catch(console.error);
@@ -279,6 +287,7 @@ class HiveAcc {
                         log(`Data published at: ${new Date()}`); //Not cure if this one will work
                         log('Successfully published feed.');
                         log(`TXID: ${r.id}`);
+                        log('-------------');
                     });
             } else {
                 console.error('Failed to publish feed... neither signing key or wif are valid');
@@ -286,6 +295,7 @@ class HiveAcc {
                 if (tries < retry_conf.feed_attempts) {
                     switchNode();
                     console.error(`Will retry in ${retry_conf.feed_delay} seconds`);
+                    console.error('-------------');
                     return delay(retry_conf.feed_delay * 1000)
                         .then(() => this.publish_feed(rate, tries + 1))
                         .catch(console.error);


### PR DESCRIPTION
Ran into an issue where retries in some cases would not execute and would just sit there for eternity.

I've made some changes that as far as I can tell fix the issue, I'd ran some tests with various incorrect settings and retries work as intended.

In my specific case, ```hived.privex.com``` was returning a ```Forbidden: 403``` error on start up and retry would not execute after 60 seconds.
This also actually fixes the error with ```resolve``` not being defined in the scope of ```publishfeed```.

I also added a little bit of break formatting to neaten up console output so it's easier to see individual published feeds.