### PR TITLE
Fix Binance adapter: replace delisted HIVE/BTC with HIVE/USDT

### DIFF
--- a/lib/adapters/BinanceAdapter.js
+++ b/lib/adapters/BinanceAdapter.js
@@ -6,7 +6,7 @@ var BinanceAdapter = {
     code: 'binance',
     provides: [
         ['btc','usdt'],
-        ['hive','btc'],
+        ['hive','usdt'],
     ],
     
     has_pair: (from, to) => BaseAdapter.has_pair_ext(from, to, BinanceAdapter.provides),


### PR DESCRIPTION
Binance delisted the HIVE/BTC market, which can lead to stale or incorrect pricing in the Binance adapter.

This change updates the Binance adapter to use HIVE/USDT instead of HIVE/BTC.